### PR TITLE
Fix for issue (#7) for adafruit macro pad and v10 adafruit display library changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ eagle.epf
 
 # file locks introduced since 7.x
 *.lck
+
+# ignore macos system files
+.DS_Store
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The firmware lives in the `circuitpython/picostepseq` directory.
    If using a Mac terminal, you can do:
    ```sh
    cd picostepseq/circuitpython/picostepseq
-   cp -rX * /Volumes/CIRUITPY
+   cp -rX * /Volumes/CIRCUITPY
    ```
 
 2. Install the CircuitPython libraries `adafruit_displayio_ssd1306` and `adafruit_display_text`

--- a/circuitpython/picostepseq/code.py
+++ b/circuitpython/picostepseq/code.py
@@ -164,7 +164,7 @@ seqr = StepSequencer(num_steps, tempo, play_note_on, play_note_off, playing=Fals
 sequences_read()
 
 seqr_display = SequencerDisplay(seqr)
-hw.display.show(seqr_display)
+hw.display.root_group = seqr_display
 
 sequence_load(0)
 


### PR DESCRIPTION
Adds macOS file system to gitignore
Fixes folder dir in readme
Switches display logic to v10 of screen logic